### PR TITLE
feat(batch): support FIFO entire batch failure override

### DIFF
--- a/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
+++ b/aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py
@@ -66,7 +66,12 @@ class SqsFifoPartialProcessor(BatchProcessor):
         None,
     )
 
-    def __init__(self, model: BatchSqsTypeModel | None = None, skip_group_on_error: bool = False):
+    def __init__(
+        self,
+        model: BatchSqsTypeModel | None = None,
+        skip_group_on_error: bool = False,
+        raise_on_entire_batch_failure: bool = True,
+    ):
         """
         Initialize the SqsFifoProcessor.
 
@@ -77,12 +82,15 @@ class SqsFifoPartialProcessor(BatchProcessor):
         skip_group_on_error: bool
             Determines whether to exclusively skip messages from the MessageGroupID that encountered processing failures
             Default is False.
+        raise_on_entire_batch_failure: bool
+            Raise an exception when the entire batch has failed processing.
+            When set to False, partial failures are reported in the response.
 
         """
         self._skip_group_on_error: bool = skip_group_on_error
         self._current_group_id = None
         self._failed_group_ids: set[str] = set()
-        super().__init__(EventType.SQS, model)
+        super().__init__(EventType.SQS, model, raise_on_entire_batch_failure)
 
     def _process_record(self, record):
         self._current_group_id = record.get("attributes", {}).get("MessageGroupId")

--- a/tests/functional/batch/required_dependencies/test_utilities_batch.py
+++ b/tests/functional/batch/required_dependencies/test_utilities_batch.py
@@ -499,6 +499,24 @@ def test_sqs_fifo_batch_processor_middleware_with_failure(sqs_event_fifo_factory
     assert result["batchItemFailures"][1]["itemIdentifier"] == third_record.message_id
 
 
+def test_sqs_fifo_batch_processor_not_raise_when_entire_batch_fails(sqs_event_fifo_factory, record_handler):
+    first_record = SQSRecord(sqs_event_fifo_factory("fail"))
+    second_record = SQSRecord(sqs_event_fifo_factory("success"))
+    event = {"Records": [first_record.raw_event, second_record.raw_event]}
+
+    processor = SqsFifoPartialProcessor(raise_on_entire_batch_failure=False)
+
+    @batch_processor(record_handler=record_handler, processor=processor)
+    def lambda_handler(event, context):
+        return processor.response()
+
+    response = lambda_handler(event, {})
+
+    assert len(response["batchItemFailures"]) == 2
+    assert response["batchItemFailures"][0]["itemIdentifier"] == first_record.message_id
+    assert response["batchItemFailures"][1]["itemIdentifier"] == second_record.message_id
+
+
 def test_sqs_fifo_batch_processor_middleware_with_skip_group_on_error(sqs_event_fifo_factory, record_handler):
     # GIVEN a batch of 5 records with 3 different MessageGroupID
     first_record = SQSRecord(sqs_event_fifo_factory("success", "1"))


### PR DESCRIPTION
Fixes #7596

## Summary
This lets `SqsFifoPartialProcessor` use the existing `raise_on_entire_batch_failure` option that `BatchProcessor` already supports.

## Why
Before this change, FIFO batch processing always raised `BatchProcessingError` when every record ended up failed, even when callers wanted the Lambda partial failure response instead. That made the FIFO processor behave differently from the standard batch processor for the same option.

## Test plan
- `.venv/bin/python -m pytest tests/functional/batch/required_dependencies/test_utilities_batch.py -k 'sqs_fifo_batch_processor'`
- `.venv/bin/python -m ruff format --check aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py tests/functional/batch/required_dependencies/test_utilities_batch.py`
- `.venv/bin/python -m ruff check aws_lambda_powertools/utilities/batch/sqs_fifo_partial_processor.py tests/functional/batch/required_dependencies/test_utilities_batch.py`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.