### PR TITLE
feat(ci): deploy layers to ap-southeast-6

### DIFF
--- a/.github/workflows/reusable_deploy_v3_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_v3_layer_stack.yml
@@ -74,7 +74,7 @@ jobs:
         # aws ec2 describe-regions --all-regions --query "Regions[].RegionName" --output text | tr "\t" "\n" | sort
         region: ["af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
                  "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3",
-                 "ap-southeast-4", "ap-southeast-5", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2",
+                 "ap-southeast-4", "ap-southeast-5", "ap-southeast-6", "ap-southeast-7", "ca-central-1", "ca-west-1", "eu-central-1", "eu-central-2",
                  "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3",
                  "il-central-1", "mx-central-1", "sa-east-1", "us-east-1",
                  "us-east-2", "us-west-1", "us-west-2"]
@@ -103,6 +103,8 @@ jobs:
           - region: "ap-southeast-4"
             has_arm64_support: "true"
           - region: "ap-southeast-5"
+            has_arm64_support: "true"
+          - region: "ap-southeast-6"
             has_arm64_support: "true"
           - region: "ap-southeast-7"
             has_arm64_support: "true"


### PR DESCRIPTION
Fixes #7355

## Summary
This adds `ap-southeast-6` to the Lambda layer deployment matrix and marks it as ARM64-capable.

## Why
AWS now has the Asia Pacific (New Zealand) region. Without this entry, the release workflow will not deploy Powertools Lambda layers there.

## Test plan
- `git diff --check`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.