### PR TITLE
refactor(event_handler): promote HttpResolver to stable

### DIFF
--- a/aws_lambda_powertools/event_handler/__init__.py
+++ b/aws_lambda_powertools/event_handler/__init__.py
@@ -18,7 +18,7 @@ from aws_lambda_powertools.event_handler.bedrock_agent_function import (
 )
 from aws_lambda_powertools.event_handler.depends import DependencyResolutionError, Depends
 from aws_lambda_powertools.event_handler.events_appsync.appsync_events import AppSyncEventsResolver
-from aws_lambda_powertools.event_handler.http_resolver import HttpResolverLocal
+from aws_lambda_powertools.event_handler.http_resolver import HttpResolver, HttpResolverLocal
 from aws_lambda_powertools.event_handler.lambda_function_url import (
     LambdaFunctionUrlResolver,
 )
@@ -39,6 +39,7 @@ __all__ = [
     "CORSConfig",
     "Depends",
     "DependencyResolutionError",
+    "HttpResolver",
     "HttpResolverLocal",
     "LambdaFunctionUrlResolver",
     "Request",

--- a/aws_lambda_powertools/event_handler/http_resolver.py
+++ b/aws_lambda_powertools/event_handler/http_resolver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import warnings
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import parse_qs
 
@@ -162,20 +161,15 @@ class MockLambdaContext:
 
 class HttpResolverLocal(ApiGatewayResolver):
     """
-    ASGI-compatible HTTP resolver for local development and testing.
+    ASGI-compatible HTTP resolver.
 
-    This resolver is designed specifically for local development workflows.
-    It allows you to run your Powertools application locally with any ASGI server
+    It allows you to run your Powertools application with any ASGI server
     (uvicorn, hypercorn, daphne, etc.) while maintaining full compatibility with Lambda.
 
     The same code works in both environments - locally via ASGI and in Lambda via the handler.
+    If your Lambda is behind Lambda Web Adapter or any other HTTP proxy, it works seamlessly.
 
     Supports both sync and async route handlers.
-
-    WARNING
-    -------
-    This is intended for local development and testing only.
-    The API may change in future releases. Do not use in production environments.
 
     Example
     -------
@@ -210,11 +204,6 @@ class HttpResolverLocal(ApiGatewayResolver):
         strip_prefixes: list[str | Any] | None = None,
         enable_validation: bool = False,
     ):
-        warnings.warn(
-            "HttpResolverLocal is intended for local development and testing only. "
-            "The API may change in future releases. Do not use in production environments.",
-            stacklevel=2,
-        )
         super().__init__(
             proxy_type=ProxyEventType.APIGatewayProxyEvent,  # Use REST API format internally
             cors=cors,
@@ -351,3 +340,6 @@ class HttpResolverLocal(ApiGatewayResolver):
                 "body": body_bytes,
             },
         )
+
+
+HttpResolver = HttpResolverLocal

--- a/docs/core/event_handler/api_gateway.md
+++ b/docs/core/event_handler/api_gateway.md
@@ -64,7 +64,7 @@ By default, we will use `APIGatewayRestResolver` throughout the documentation. Y
 | **[`ALBResolver`](#application-load-balancer)**         | Amazon Application Load Balancer (ALB) |
 | **[`LambdaFunctionUrlResolver`](#lambda-function-url)** | AWS Lambda Function URL                |
 | **[`VPCLatticeResolver`](#vpc-lattice)**                | Amazon VPC Lattice                     |
-| **[`HttpResolverLocal`](#http-resolver-local)**         | Local development with ASGI servers    |
+| **[`HttpResolverLocal`](#http-resolver-local)**         | ASGI-compatible resolver               |
 <!-- markdownlint-enable MD051 -->
 
 #### Response auto-serialization

--- a/docs/includes/_http_resolver_local.md
+++ b/docs/includes/_http_resolver_local.md
@@ -1,11 +1,7 @@
 <!-- markdownlint-disable MD041 MD043 -->
-#### Http Resolver (Local Development)
+#### Http Resolver (ASGI)
 
-???+ warning "Local Development Only"
-    `HttpResolverLocal` is intended for local development and testing only.
-    The API may change in future releases. **Do not use in production environments.**
-
-When developing locally, you can use `HttpResolverLocal` to run your API with any ASGI server like [uvicorn](https://www.uvicorn.org/){target="_blank"}. It implements the [ASGI specification](https://asgi.readthedocs.io/){target="_blank"}, is lightweight with no external dependencies, and the same code works on any compute platform, including Lambda.
+`HttpResolver` is an ASGI-compatible resolver that lets you run your Powertools application with any ASGI server like [uvicorn](https://www.uvicorn.org/){target="_blank"}. It implements the [ASGI specification](https://asgi.readthedocs.io/){target="_blank"}, is lightweight with no external dependencies, and works seamlessly with Lambda or any environment that speaks HTTP.
 
 If your Lambda is behind [Lambda Web Adapter](https://github.com/awslabs/aws-lambda-web-adapter){target="_blank"} or any other HTTP proxy that speaks the HTTP protocol, it works seamlessly.
 

--- a/examples/event_handler_rest/src/http_resolver_basic.py
+++ b/examples/event_handler_rest/src/http_resolver_basic.py
@@ -1,6 +1,6 @@
-from aws_lambda_powertools.event_handler import HttpResolverLocal
+from aws_lambda_powertools.event_handler import HttpResolver
 
-app = HttpResolverLocal()
+app = HttpResolver()
 
 
 @app.get("/hello/<name>")

--- a/examples/event_handler_rest/src/http_resolver_exception_handling.py
+++ b/examples/event_handler_rest/src/http_resolver_exception_handling.py
@@ -1,6 +1,6 @@
-from aws_lambda_powertools.event_handler import HttpResolverLocal, Response
+from aws_lambda_powertools.event_handler import HttpResolver, Response
 
-app = HttpResolverLocal()
+app = HttpResolver()
 
 
 class NotFoundError(Exception):

--- a/examples/event_handler_rest/src/http_resolver_validation_swagger.py
+++ b/examples/event_handler_rest/src/http_resolver_validation_swagger.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from aws_lambda_powertools.event_handler import HttpResolverLocal
+from aws_lambda_powertools.event_handler import HttpResolver
 
 
 class User(BaseModel):
@@ -8,7 +8,7 @@ class User(BaseModel):
     age: int
 
 
-app = HttpResolverLocal(enable_validation=True)
+app = HttpResolver(enable_validation=True)
 
 app.enable_swagger(
     title="My API",

--- a/tests/functional/event_handler/_pydantic/test_http_resolver_pydantic.py
+++ b/tests/functional/event_handler/_pydantic/test_http_resolver_pydantic.py
@@ -13,10 +13,6 @@ from aws_lambda_powertools.event_handler import HttpResolverLocal
 from aws_lambda_powertools.event_handler.http_resolver import MockLambdaContext
 from aws_lambda_powertools.event_handler.openapi.params import Query
 
-# Suppress warning for all tests
-pytestmark = pytest.mark.filterwarnings("ignore:HttpResolverLocal is intended for local development")
-
-
 # =============================================================================
 # ASGI Test Helpers
 # =============================================================================

--- a/tests/functional/event_handler/required_dependencies/test_http_resolver.py
+++ b/tests/functional/event_handler/required_dependencies/test_http_resolver.py
@@ -1,4 +1,4 @@
-"""Tests for HttpResolverLocal - ASGI-compatible HTTP resolver for local development."""
+"""Tests for HttpResolverLocal - ASGI-compatible HTTP resolver."""
 
 from __future__ import annotations
 
@@ -10,10 +10,6 @@ import pytest
 
 from aws_lambda_powertools.event_handler import HttpResolverLocal, Response
 from aws_lambda_powertools.event_handler.http_resolver import MockLambdaContext
-
-# Suppress warning for all tests
-pytestmark = pytest.mark.filterwarnings("ignore:HttpResolverLocal is intended for local development")
-
 
 # =============================================================================
 # ASGI Test Helpers


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8288 

## Summary

Promote `HttpResolverLocal` to stable by introducing an HttpResolver alias. The original class remains for backward compatibility but all docs, examples, and messaging now use HttpResolver with ASGI-focused.

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
