### PR TITLE
fix(circuit_breaker): normalize handled/ignored exceptions to a validated tuple at construction

### DIFF
--- a/aws_lambda_powertools/utilities/circuit_breaker_alpha/config.py
+++ b/aws_lambda_powertools/utilities/circuit_breaker_alpha/config.py
@@ -4,7 +4,12 @@ Configuration for the Circuit Breaker utility.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from aws_lambda_powertools.utilities.circuit_breaker_alpha.exceptions import CircuitBreakerConfigError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class CircuitBreakerConfig:
@@ -24,12 +29,14 @@ class CircuitBreakerConfig:
     success_threshold : int
         Number of *consecutive* probe successes required to close a half-open circuit.
         Defaults to 3.
-    handled_exceptions : tuple[type[Exception], ...] | None
+    handled_exceptions : type[Exception] | Iterable[type[Exception]] | None
         Allowlist: only these exception types count as failures; anything else
-        propagates without affecting the circuit. Mutually exclusive with
+        propagates without affecting the circuit. Accepts a single exception type or
+        an iterable of them (normalized to a tuple). Mutually exclusive with
         ``ignored_exceptions``. Defaults to ``None`` (treated as ``(Exception,)``).
-    ignored_exceptions : tuple[type[Exception], ...] | None
-        Denylist: every exception counts as a failure *except* these. Mutually
+    ignored_exceptions : type[Exception] | Iterable[type[Exception]] | None
+        Denylist: every exception counts as a failure *except* these. Accepts a single
+        exception type or an iterable of them (normalized to a tuple). Mutually
         exclusive with ``handled_exceptions``. Defaults to ``None``.
     local_cache_max_age : int
         Seconds a circuit's state is cached in the execution environment before a
@@ -38,8 +45,9 @@ class CircuitBreakerConfig:
     Raises
     ------
     CircuitBreakerConfigError
-        If both ``handled_exceptions`` and ``ignored_exceptions`` are provided, or a
-        numeric tunable is not a positive integer.
+        If both ``handled_exceptions`` and ``ignored_exceptions`` are provided, a
+        numeric tunable is not a positive integer, or an exception allowlist/denylist
+        is empty or contains a value that is not an exception type.
 
     Example
     -------
@@ -57,10 +65,16 @@ class CircuitBreakerConfig:
         failure_threshold: int = 5,
         recovery_timeout: int = 30,
         success_threshold: int = 3,
-        handled_exceptions: tuple[type[Exception], ...] | None = None,
-        ignored_exceptions: tuple[type[Exception], ...] | None = None,
+        handled_exceptions: type[Exception] | Iterable[type[Exception]] | None = None,
+        ignored_exceptions: type[Exception] | Iterable[type[Exception]] | None = None,
         local_cache_max_age: int = 5,
     ):
+        # Normalize first: a single exception type or any iterable becomes a tuple, and a
+        # bad value fails here (at construction) rather than as a cryptic isinstance
+        # TypeError later, the first time the circuit evaluates a failure.
+        handled_exceptions = self._normalize_exceptions(handled_exceptions, "handled_exceptions")
+        ignored_exceptions = self._normalize_exceptions(ignored_exceptions, "ignored_exceptions")
+
         self._validate(
             failure_threshold=failure_threshold,
             recovery_timeout=recovery_timeout,
@@ -104,6 +118,47 @@ class CircuitBreakerConfig:
             raise CircuitBreakerConfigError(
                 f"local_cache_max_age must be a non-negative integer, got {local_cache_max_age!r}.",
             )
+
+    @classmethod
+    def _normalize_exceptions(
+        cls,
+        value: type[Exception] | Iterable[type[Exception]] | None,
+        field: str,
+    ) -> tuple[type[Exception], ...] | None:
+        """Coerce a single exception type or an iterable of them into a validated, non-empty tuple.
+
+        Runs at construction so a bad value fails immediately with a clear error, rather
+        than as a cryptic ``isinstance`` ``TypeError`` from ``counts_as_failure`` the
+        first time the circuit evaluates a failure (i.e. only once the dependency is
+        already unhealthy).
+        """
+        if value is None:
+            return None
+
+        invalid = f"{field} must be an exception type or an iterable of exception types, got {value!r}."
+        # A str is iterable; reject it rather than iterate it as a sequence of characters.
+        if isinstance(value, str):
+            raise CircuitBreakerConfigError(invalid)
+
+        if isinstance(value, type):
+            exceptions: tuple[type[Exception], ...] = (value,)
+        else:
+            try:
+                exceptions = tuple(value)
+            except TypeError:
+                raise CircuitBreakerConfigError(invalid) from None
+
+        cls._validate_exception_types(exceptions, field)
+        return exceptions
+
+    @staticmethod
+    def _validate_exception_types(exceptions: tuple[type[Exception], ...], field: str) -> None:
+        """Require a non-empty tuple whose every element is an exception type."""
+        if not exceptions:
+            raise CircuitBreakerConfigError(f"{field} must contain at least one exception type.")
+        for exception in exceptions:
+            if not (isinstance(exception, type) and issubclass(exception, Exception)):
+                raise CircuitBreakerConfigError(f"{field} must contain only exception types, got {exception!r}.")
 
     def counts_as_failure(self, exception: Exception) -> bool:
         """

--- a/aws_lambda_powertools/utilities/circuit_breaker_alpha/config.py
+++ b/aws_lambda_powertools/utilities/circuit_breaker_alpha/config.py
@@ -141,7 +141,8 @@ class CircuitBreakerConfig:
             raise CircuitBreakerConfigError(invalid)
 
         if isinstance(value, type):
-            exceptions: tuple[type[Exception], ...] = (value,)
+            # ty (unlike mypy) does not narrow the union here, so it needs the ignore.
+            exceptions: tuple[type[Exception], ...] = (value,)  # ty: ignore[invalid-assignment]
         else:
             try:
                 exceptions = tuple(value)

--- a/aws_lambda_powertools/utilities/circuit_breaker_alpha/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/circuit_breaker_alpha/persistence/dynamodb.py
@@ -15,6 +15,7 @@ from boto3.dynamodb.types import TypeDeserializer
 from botocore.exceptions import ClientError
 
 from aws_lambda_powertools.shared import constants, user_agent
+from aws_lambda_powertools.utilities.circuit_breaker_alpha.exceptions import CircuitBreakerConfigError
 from aws_lambda_powertools.utilities.circuit_breaker_alpha.persistence.base import (
     CircuitBreakerExistingLockError,
     CircuitBreakerPersistenceLayer,
@@ -105,7 +106,9 @@ class CircuitBreakerDynamoDBPersistence(CircuitBreakerPersistenceLayer):
         user_agent.register_feature_to_client(client=self.client, feature="circuit_breaker")
 
         if sort_key_attr == key_attr:
-            raise ValueError(f"key_attr [{key_attr}] and sort_key_attr [{sort_key_attr}] cannot be the same!")
+            raise CircuitBreakerConfigError(
+                f"key_attr [{key_attr}] and sort_key_attr [{sort_key_attr}] cannot be the same!",
+            )
 
         if static_pk_value is not None and sort_key_attr is None:
             warnings.warn(

--- a/tests/functional/circuit_breaker_alpha/test_dynamodb_persistence.py
+++ b/tests/functional/circuit_breaker_alpha/test_dynamodb_persistence.py
@@ -6,6 +6,7 @@ from botocore.config import Config
 from botocore.stub import Stubber
 
 from aws_lambda_powertools.utilities.circuit_breaker_alpha.config import CircuitBreakerConfig
+from aws_lambda_powertools.utilities.circuit_breaker_alpha.exceptions import CircuitBreakerConfigError
 from aws_lambda_powertools.utilities.circuit_breaker_alpha.persistence import (
     CircuitBreakerDynamoDBPersistence,
 )
@@ -371,7 +372,7 @@ def test_composite_item_to_record_reads_name_from_sort_key(composite_persistence
 
 def test_sort_key_equal_to_key_attr_raises():
     client = boto3.client("dynamodb", config=Config(region_name="us-east-1"))
-    with pytest.raises(ValueError, match="cannot be the same"):
+    with pytest.raises(CircuitBreakerConfigError, match="cannot be the same"):
         CircuitBreakerDynamoDBPersistence(
             table_name=TABLE_NAME,
             boto3_client=client,

--- a/tests/unit/circuit_breaker_alpha/test_config_and_states.py
+++ b/tests/unit/circuit_breaker_alpha/test_config_and_states.py
@@ -72,6 +72,51 @@ def test_counts_as_failure_denylist():
     assert config.counts_as_failure(KeyError()) is True
 
 
+def test_config_normalizes_handled_exceptions_list_to_tuple():
+    config = CircuitBreakerConfig(handled_exceptions=[TimeoutError, ConnectionError])
+    assert config.handled_exceptions == (TimeoutError, ConnectionError)
+    # The reported bug: a list must not break counts_as_failure when the circuit evaluates a failure.
+    assert config.counts_as_failure(TimeoutError()) is True
+    assert config.counts_as_failure(ValueError()) is False
+
+
+def test_config_normalizes_single_exception_type_to_tuple():
+    config = CircuitBreakerConfig(handled_exceptions=ValueError)
+    assert config.handled_exceptions == (ValueError,)
+    assert config.counts_as_failure(ValueError()) is True
+
+
+def test_config_normalizes_ignored_exceptions_list_to_tuple():
+    config = CircuitBreakerConfig(ignored_exceptions=[ValueError])
+    assert config.ignored_exceptions == (ValueError,)
+    assert config.counts_as_failure(ValueError()) is False
+    assert config.counts_as_failure(KeyError()) is True
+
+
+def test_config_normalizes_iterator_of_exceptions():
+    config = CircuitBreakerConfig(handled_exceptions=iter((TimeoutError, KeyError)))
+    assert config.handled_exceptions == (TimeoutError, KeyError)
+
+
+@pytest.mark.parametrize("field", ["handled_exceptions", "ignored_exceptions"])
+def test_config_rejects_non_exception_type_in_list(field):
+    with pytest.raises(CircuitBreakerConfigError, match="only exception types"):
+        CircuitBreakerConfig(**{field: ["not-an-exception"]})
+
+
+@pytest.mark.parametrize("field", ["handled_exceptions", "ignored_exceptions"])
+@pytest.mark.parametrize("value", [5, "ValueError"])
+def test_config_rejects_non_iterable_or_str_exceptions(field, value):
+    with pytest.raises(CircuitBreakerConfigError, match="iterable of exception types"):
+        CircuitBreakerConfig(**{field: value})
+
+
+@pytest.mark.parametrize("field", ["handled_exceptions", "ignored_exceptions"])
+def test_config_rejects_empty_exceptions(field):
+    with pytest.raises(CircuitBreakerConfigError, match="at least one exception type"):
+        CircuitBreakerConfig(**{field: []})
+
+
 def test_open_error_carries_circuit_info():
     info = CircuitInfo(name="payment", state=CircuitState.OPEN, failure_count=5, opened_at=123)
     error = CircuitBreakerOpenError("open", circuit=info)


### PR DESCRIPTION
**Issue number:** closes #8317

## Summary

### Changes

`CircuitBreakerConfig` stored `handled_exceptions`/`ignored_exceptions` verbatim and used them directly in `isinstance(exception, self.handled_exceptions)`. Passing a **list** constructed fine but raised `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union` later — only when a circuit tripped, i.e. only under a real downstream failure. Because `counts_as_failure` raises before the failure is counted, it masks the original error and the circuit never opens.

Both params now go through a `_normalize_exceptions` step in `__init__` that accepts a single exception type or any iterable of them (normalizing to a tuple), and validates the result is a non-empty tuple of exception types — raising `CircuitBreakerConfigError` at construction instead of a cryptic `TypeError` later. Mirrors how `event_handler`'s exception handler already accepts a single class or a list. A bare `tuple(...)` (as in #8318) isn't enough: it regresses the single-type case (`tuple(SomeException)` raises) and skips validation.

### User experience

Before:

```python
CircuitBreakerConfig(handled_exceptions=[TimeoutError])   # ok at construction
# ...first time the downstream fails:
# TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

After: the list just works; genuinely bad input (a non-exception element, a non-iterable, an empty list, a str) fails immediately at construction with a clear `CircuitBreakerConfigError`.

### Tests

New unit tests in `test_config_and_states.py`: list/generator → tuple, single type → tuple (the #8318 regression), and rejection of an empty iterable, a non-exception element, a non-iterable, and a str. `pytest` (unit + functional), `make mypy`, ruff, and the security/complexity baselines all pass.

---

One thing I noticed while in here — totally non-blocking, just curious: the exceptions have a slightly different feel across the utility. Config validation raises `CircuitBreakerConfigError`, but `CircuitBreakerDynamoDBPersistence`'s `sort_key_attr == key_attr` check raises a bare `ValueError`, so `except CircuitBreakerError` catches every construction/config problem *except* that one. It's tiny at runtime (fails fast at setup), but since it's alpha it felt like the cheap moment to raise it, before changing it would be a breaking change. Would you want construction-time validation unified under `CircuitBreakerError`, or is the `ValueError` deliberate? Happy to fold it into this PR or do a quick follow-up — whatever suits.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
