### PR TITLE
fix(parser): fix DynamoDB Stream Lambda invocation record model

### DIFF
--- a/aws_lambda_powertools/event_handler/events_appsync/appsync_events.py
+++ b/aws_lambda_powertools/event_handler/events_appsync/appsync_events.py
@@ -321,7 +321,7 @@ class AppSyncEventsResolver(Router):
                     if isinstance(ret, Exception)
                     else {"id": e.get("id"), "payload": ret}
                 )
-                for e, ret in zip(self.current_event.events, results)
+                for e, ret in zip(self.current_event.events, results, strict=True)
             ],
         )
 

--- a/aws_lambda_powertools/utilities/parser/models/dynamodb.py
+++ b/aws_lambda_powertools/utilities/parser/models/dynamodb.py
@@ -175,7 +175,8 @@ class ResponseContext(BaseModel):
         description="The version of the Lambda executed",
         examples=["$LATEST"],
     )
-    function_error: str = Field(
+    function_error: Optional[str] = Field(
+        default=None,
         description="",
         examples=["Unhandled"],
     )

--- a/ruff.toml
+++ b/ruff.toml
@@ -41,6 +41,10 @@ lint.ignore = [
     "A005",
     "TC006", # https://docs.astral.sh/ruff/rules/runtime-cast-value/
     "PLC0415", # https://docs.astral.sh/ruff/rules/import-outside-top-level/
+    "UP006",
+    "UP007",
+    "UP035",
+    "UP045",
 ]
 
 # Exclude files and directories
@@ -62,7 +66,7 @@ exclude = [
 # Maximum line length
 line-length = 120
 
-target-version = "py38"
+target-version = "py310"
 
 fix = true
 lint.fixable = ["I", "COM812", "W"]

--- a/tests/unit/data_classes/required_dependencies/test_bedrock_agent_function_event.py
+++ b/tests/unit/data_classes/required_dependencies/test_bedrock_agent_function_event.py
@@ -32,7 +32,7 @@ def test_bedrock_agent_function_event():
     raw_parameters = raw_event["parameters"]
     assert len(parameters) == len(raw_parameters)
 
-    for param, raw_param in zip(parameters, raw_parameters):
+    for param, raw_param in zip(parameters, raw_parameters, strict=True):
         assert param.name == raw_param["name"]
         assert param.type == raw_param["type"]
         assert param.value == raw_param["value"]

--- a/tests/unit/parser/_pydantic/test_dynamodb.py
+++ b/tests/unit/parser/_pydantic/test_dynamodb.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from aws_lambda_powertools.utilities.parser import ValidationError, envelopes, parse
@@ -86,8 +88,26 @@ def test_validate_event_does_not_conform_with_model():
         parse(event=raw_event, model=MyDynamoBusiness, envelope=envelopes.DynamoDBStreamEnvelope)
 
 
-def test_dynamo_db_stream_lambda_invocation_event():
+@pytest.mark.parametrize(
+    "response_context",
+    [
+        pytest.param(
+            {"statusCode": 200, "executedVersion": "$LATEST"},
+            id="without function error",
+        ),
+        pytest.param(
+            {"statusCode": 200, "executedVersion": "$LATEST", "functionError": None},
+            id="with null function error",
+        ),
+        pytest.param(
+            {"statusCode": 200, "executedVersion": "$LATEST", "functionError": "Unhandled"},
+            id="with function error",
+        ),
+    ],
+)
+def test_dynamo_db_stream_lambda_invocation_event(response_context: dict[str, Any]):
     raw_event = load_event("dynamoStreamLambdaInvocationEvent.json")
+    raw_event["responseContext"] = response_context
     parsed_event: DynamoDBStreamLambdaOnFailureDestinationModel = parse(
         event=raw_event,
         model=DynamoDBStreamLambdaOnFailureDestinationModel,
@@ -111,6 +131,8 @@ def test_dynamo_db_stream_lambda_invocation_event():
     )
     assert parsed_event.ddb_stream_batch_info.stream_arn == raw_event["DDBStreamBatchInfo"]["streamArn"]
     assert parsed_event.request_context.model_dump(by_alias=True) == raw_event["requestContext"]
-    assert parsed_event.response_context.model_dump(by_alias=True) == raw_event["responseContext"]
+    assert parsed_event.response_context.status_code == response_context["statusCode"]
+    assert parsed_event.response_context.executed_version == response_context["executedVersion"]
+    assert parsed_event.response_context.function_error == response_context.get("functionError")
     assert parsed_event.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ") == raw_event["timestamp"]
     assert parsed_event.version == raw_event["version"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8322

## Summary

The PR fixes an issue in the DynamoDB Stream Lambda Invocation record data model introduced in #7818.

### Changes

The responseContext.functionError field of a DynamoDB Stream Lambda Invocation record is null if the error did not occur during function execution.

### User experience

> Please share what the user experience looks like before and after this change

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
