### PR TITLE
fix(event_source): mypy strict mode compliance

### DIFF
--- a/aws_lambda_powertools/utilities/data_classes/event_source.py
+++ b/aws_lambda_powertools/utilities/data_classes/event_source.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast
 
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 
@@ -10,14 +10,30 @@ if TYPE_CHECKING:
     from aws_lambda_powertools.utilities.data_classes.common import DictWrapper
     from aws_lambda_powertools.utilities.typing import LambdaContext
 
+DataClassT = TypeVar("DataClassT", bound="DictWrapper")
+OutputT = TypeVar("OutputT")
+
+
+class _EventSourceDecorator(Protocol):
+    """Annotation of event_source, that lambda_handler_decorator erases at runtime."""
+
+    def __call__(
+        self,
+        *,
+        data_class: type[DataClassT],
+    ) -> Callable[
+        [Callable[[DataClassT, LambdaContext], OutputT]],
+        Callable[[dict[str, Any], LambdaContext], OutputT],
+    ]: ...
+
 
 @lambda_handler_decorator
-def event_source(
-    handler: Callable[[Any, LambdaContext], Any],
+def _event_source(
+    handler: Callable[[Any, LambdaContext], OutputT],
     event: dict[str, Any],
     context: LambdaContext,
-    data_class: type[DictWrapper],
-):
+    data_class: type[DataClassT],
+) -> OutputT:
     """Middleware to create an instance of the passed in event source data class
 
     Parameters
@@ -43,3 +59,6 @@ def event_source(
              return {"key": event.object_key}
     """
     return handler(data_class(event), context)
+
+
+event_source = cast(_EventSourceDecorator, _event_source)

--- a/examples/event_sources/src/kinesis_firehose_response_exception.py
+++ b/examples/event_sources/src/kinesis_firehose_response_exception.py
@@ -9,11 +9,10 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 
 
 @event_source(data_class=KinesisFirehoseEvent)
-def lambda_handler(event: dict, context: LambdaContext):
-    firehose_event = KinesisFirehoseEvent(event)
+def lambda_handler(event: KinesisFirehoseEvent, context: LambdaContext):
     result = KinesisFirehoseDataTransformationResponse()
 
-    for record in firehose_event.records:
+    for record in event.records:
         try:
             payload = record.data_as_text  # base64 decoded data as str
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8331

## Summary

### Changes

`aws_lambda_powertools.utilities.data_classes.event_source` complies with `mypy` in `--strict` mode as well.

Removed a redundant casting to the dataclass in `examples/event_sources/src/kinesis_firehose_response_exception.py`.

Changes are localised to `event_source.py`, rather than trying to annotate `lambda_handler_decorator` for all use cases, unlike earlier attempts, e.g. #4165. Since the decorator only takes the dataclass as a keyword argument, I've defined a protocol and cast the result to this.


### User experience

Having a handler using the `@event_source` decorator, in `main.py`

```python
from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
from aws_lambda_powertools.utilities.typing import LambdaContext


@event_source(data_class=SQSEvent)
def lambda_handler(event: SQSEvent, _context: LambdaContext) -> None:
    return None

```

Before:
```
$ mypy --strict main.py

main.py:5:2: error: Untyped decorator makes function "lambda_handler" untyped  [untyped-decorator]
```

After:
```
$ mypy --strict main.py 

Success: no issues found in 1 source file
```


<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
