### PR TITLE
docs(metadata): clarify public import path for get_lambda_metadata

### DIFF
--- a/docs/utilities/metadata.md
+++ b/docs/utilities/metadata.md
@@ -21,6 +21,17 @@ The Metadata utility allows you to fetch data from the [AWS Lambda Metadata Endp
 
 You can fetch data from the Lambda Metadata Endpoint using the `get_lambda_metadata` function.
 
+Import it from `aws_lambda_powertools.utilities.metadata` (the public package path):
+
+```python
+from aws_lambda_powertools.utilities.metadata import get_lambda_metadata
+```
+
+???+ warning "Import path is `utilities.metadata`"
+    The correct module path is `aws_lambda_powertools.utilities.metadata`.
+
+    Do **not** import from `aws_lambda_powertools.utilities.lambda_metadata` — that path is not part of the public API (even though the implementation file and `get_lambda_metadata` helper share a similar name).
+
 ???+ tip
     Metadata is cached for the duration of the Lambda sandbox, so subsequent calls to `get_lambda_metadata` will return the cached data.
 


### PR DESCRIPTION
## Summary
Clarifies the public import path for the Metadata utility so it matches the code (`aws_lambda_powertools.utilities.metadata`), and warns against the incorrect `utilities.lambda_metadata` module path.

Fixes #8056 (Powertools docs clarification; AWS Lambda developer guide example may still need a separate docs-team update).

## Changes
- `docs/utilities/metadata.md`: show the correct import snippet and add a warning callout about the wrong path

## Test plan
- [ ] Skim Metadata docs page for accuracy vs `aws_lambda_powertools/utilities/metadata/`
- [ ] Confirm examples still use `from aws_lambda_powertools.utilities.metadata import ...`

Docs-only; no AWS credentials required.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.