### PR TITLE
fix(streaming): _S3SeekableIO.__next__/__iter__ don't advance self._position, corrupting subsequent seek()/read()

### DIFF
--- a/aws_lambda_powertools/utilities/streaming/_s3_seekable_io.py
+++ b/aws_lambda_powertools/utilities/streaming/_s3_seekable_io.py
@@ -169,10 +169,16 @@ class _S3SeekableIO(IO[bytes]):
         return self._closed
 
     def __next__(self):
-        return self.raw_stream.__next__()
+        # Route through readline() (not raw_stream.__next__()) so self._position is kept in sync with
+        # bytes actually consumed. Without this, a seek() following iteration computes offsets relative
+        # to a stale self._position, causing subsequent reads to silently return the wrong byte range.
+        line = self.readline()
+        if not line:
+            raise StopIteration
+        return line
 
     def __iter__(self):
-        return self.raw_stream.__iter__()
+        return self
 
     def __enter__(self):
         return self

--- a/tests/functional/streaming/_boto3/test_s3_seekable_io.py
+++ b/tests/functional/streaming/_boto3/test_s3_seekable_io.py
@@ -163,6 +163,65 @@ def test_next(s3_seekable_obj, s3_client_stub):
         next(s3_seekable_obj)
 
 
+def test_next_advances_position(s3_seekable_obj, s3_client_stub):
+    payload = b"hello world\nworld hello"
+    streaming_body = PowertoolsStreamingBody(raw_stream=io.BytesIO(payload), content_length=len(payload))
+
+    s3_client_stub.add_response(
+        "get_object",
+        {"Body": streaming_body},
+        {"Bucket": s3_seekable_obj.bucket, "Key": s3_seekable_obj.key, "Range": "bytes=0-"},
+    )
+
+    assert next(s3_seekable_obj) == b"hello world\n"
+    # Regression: __next__ must advance self._position the same way read()/readline() do.
+    # Before the fix, __next__ delegated straight to raw_stream.__next__(), leaving
+    # self._position stuck at 0 -- so tell() (and any seek() relative to it) would be wrong.
+    assert s3_seekable_obj.tell() == len(b"hello world\n")
+
+    assert next(s3_seekable_obj) == b"world hello"
+    assert s3_seekable_obj.tell() == len(payload)
+
+    with pytest.raises(StopIteration):
+        next(s3_seekable_obj)
+
+
+def test_iter_returns_self(s3_seekable_obj):
+    # Standard Python iterator protocol: __iter__ must return the object itself, not a
+    # separate iterator over the underlying raw stream (which would bypass position tracking).
+    assert iter(s3_seekable_obj) is s3_seekable_obj
+
+
+def test_seek_after_iteration_uses_correct_range(s3_seekable_obj, s3_client_stub):
+    payload = b"hello world\nworld hello"
+    streaming_body = PowertoolsStreamingBody(raw_stream=io.BytesIO(payload), content_length=len(payload))
+
+    s3_client_stub.add_response(
+        "get_object",
+        {"Body": streaming_body},
+        {"Bucket": s3_seekable_obj.bucket, "Key": s3_seekable_obj.key, "Range": "bytes=0-"},
+    )
+
+    # Consume the stream via the iterator protocol (e.g. "for line in s3_object: ...")
+    consumed = list(s3_seekable_obj)
+    total_consumed = sum(len(line) for line in consumed)
+
+    # Seeking forward by 5 bytes from here must compute against the TRUE current position
+    # (total_consumed + 5), not a stale position left over from before iteration began.
+    s3_seekable_obj.seek(5, io.SEEK_CUR)
+
+    s3_client_stub.add_response(
+        "get_object",
+        {"Body": ""},
+        {
+            "Bucket": s3_seekable_obj.bucket,
+            "Key": s3_seekable_obj.key,
+            "Range": f"bytes={total_consumed + 5}-",
+        },
+    )
+    assert s3_seekable_obj.raw_stream is not None
+
+
 def test_context_manager(s3_seekable_obj, s3_client_stub):
     payload = b"test"
     streaming_body = PowertoolsStreamingBody(raw_stream=io.BytesIO(payload), content_length=len(payload))


### PR DESCRIPTION
### Issue number

Fixes #8388

### Summary

Fixes a bug where iterating an `_S3SeekableIO`/`S3Object` stream (`for line in s3_object: ...` or `next(s3_object)`) leaves `self._position` stuck at its pre-iteration value, so a subsequent `seek()` computes the wrong S3 byte range and the following `read()` silently returns the wrong slice of the object.

### Changes

`__next__` and `__iter__` previously delegated straight to `raw_stream.__next__()`/`raw_stream.__iter__()`:

```python
def __next__(self):
    return self.raw_stream.__next__()

def __iter__(self):
    return self.raw_stream.__iter__()
```

Unlike `read()`/`readline()`/`readlines()` (which all advance `self._position` by the number of bytes actually consumed), this bypassed position bookkeeping entirely. `seek()` uses `self._position` as ground truth to build the `Range` header on the next `raw_stream` access, so any `seek()` after iterating would compute an offset relative to a stale position.

Fix: route `__next__` through the already position-tracked `readline()`, and have `__iter__` return `self`, matching the standard Python file-iterator protocol:

```python
def __next__(self):
    line = self.readline()
    if not line:
        raise StopIteration
    return line

def __iter__(self):
    return self
```

This is functionally equivalent for consumers that only care about line-by-line iteration (the common case), while keeping position tracking correct for anyone who seeks after iterating.

### User experience

Before this fix, code like:
```python
for line in s3_object:
    ...
s3_object.seek(5, io.SEEK_CUR)
s3_object.read(...)
```
would silently read the wrong bytes after the seek, with no exception raised. After this fix, position tracking stays correct across iteration, so `seek()`/`read()` behave correctly regardless of whether the stream was previously consumed via `.read()` or via iteration.

### Checklist

- [x] My changes are covered by tests
- [x] I have added/updated the `develop` branch docs, if applicable — N/A, internal bug fix, no public API/behavior change for correctly-functioning code paths

### Is this a breaking change?

**NO**. `__iter__` returning `self` instead of `raw_stream`'s iterator, and `__next__` routing through `readline()`, are both drop-in-compatible with the existing documented iteration usage (`for line in s3_object`, `next(s3_object)`) — only the previously-broken position tracking changes.

### Tests

Added to `tests/functional/streaming/_boto3/test_s3_seekable_io.py`:
- `test_next_advances_position` — verifies `tell()` correctly reflects bytes consumed via `next()`
- `test_iter_returns_self` — standard iterator protocol check
- `test_seek_after_iteration_uses_correct_range` — reproduces the real failure mode: iterate the stream, then seek, and verify the resulting `Range` header reflects true consumed position rather than the stale pre-iteration value

All three fail against the pre-fix code (verified by reverting the fix locally and re-running; the seek test shows the exact bug live: expected `bytes=28-`, received `bytes=5-`) and pass after the fix.

Full suite `tests/functional/streaming/_boto3/test_s3_seekable_io.py`: 24 passed (independently re-verified).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.