### PR TITLE
chore(ci): omit null layer metadata fields

### DIFF
--- a/.github/workflows/layers_partitions.yml
+++ b/.github/workflows/layers_partitions.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Create Layer
         id: create-layer
         run: |
-          cat '${{ matrix.layer }}-${{ matrix.arch }}.json' | jq '{"LayerName": "${{ matrix.layer }}-${{ matrix.arch }}", "Description": .Description, "CompatibleRuntimes": .CompatibleRuntimes, "CompatibleArchitectures": .CompatibleArchitectures, "LicenseInfo": .LicenseInfo}' > input.json
+          jq '{"LayerName": "${{ matrix.layer }}-${{ matrix.arch }}", "Description": .Description, "CompatibleRuntimes": .CompatibleRuntimes, "CompatibleArchitectures": .CompatibleArchitectures, "LicenseInfo": .LicenseInfo} | with_entries(select(.value != null))' '${{ matrix.layer }}-${{ matrix.arch }}.json' > input.json
 
           LAYER_VERSION=$(aws --region ${{ matrix.region}} lambda publish-layer-version \
             --zip-file 'fileb://./${{ matrix.layer }}-${{ matrix.arch }}.zip' \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8417

## Summary

### Changes

Omit null optional metadata fields when constructing the partition layer publish request. Placeholder layer versions can omit fields such as `LicenseInfo`; passing those fields as JSON `null` causes AWS CLI parameter validation to fail before deployment.

### User experience

Partition deployments can copy placeholder layer versions without failing on absent optional metadata. This change does not alter partition synchronization behavior.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.