### PR TITLE
fix(feature_flags): missing context key never satisfies a condition

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
+++ b/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
@@ -82,10 +82,26 @@ class FeatureFlags:
         self.logger = logger or logging.getLogger(__name__)
         self._exception_handlers: dict[Exception, Callable] = {}
 
-    def _match_by_action(self, action: str, condition_value: Any, context_value: Any) -> bool:
+    def _match_by_action(
+        self,
+        action: str,
+        condition_value: Any,
+        context_value: Any,
+        context_key_present: bool = True,
+    ) -> bool:
         try:
             func = RULE_ACTION_MAPPING.get(action, lambda a, b: False)
-            return func(context_value, condition_value)
+            matched = func(context_value, condition_value)
+
+            if not context_key_present:
+                # A key absent from the context never satisfies a condition. Without this, `None` would be
+                # compared as a regular value and negative actions (NOT_EQUALS, NOT_IN, ...) would match.
+                # We still run the comparator first so that any exception it raises (e.g. ANY_IN_VALUE on a
+                # non-list) reaches registered validation exception handlers exactly as it did before.
+                self.logger.debug(f"context key not present, condition does not match: action={action}")
+                return False
+
+            return matched
         except Exception as exc:
             self.logger.debug(f"caught exception while matching action: action={action}, exception={str(exc)}")
 
@@ -118,6 +134,7 @@ class FeatureFlags:
             cond_key = condition.get(schema.CONDITION_KEY, "")
             cond_action = condition.get(schema.CONDITION_ACTION, "")
             cond_value = condition.get(schema.CONDITION_VALUE)
+            context_key_present = True
 
             # time based rule actions have no user context. the context is the condition key
             if cond_action in (
@@ -126,18 +143,16 @@ class FeatureFlags:
                 schema.RuleAction.SCHEDULE_BETWEEN_DAYS_OF_WEEK.value,
             ):
                 context_value = cond_key  # e.g., CURRENT_TIME
-            elif cond_key not in context:
-                # A key absent from the context never satisfies a condition. Without this guard, `None`
-                # would be compared as a regular value and negative actions (NOT_EQUALS, NOT_IN, ...) would match.
-                self.logger.debug(
-                    f"rule did not match, context key not found, rule_name={rule_name}, "
-                    f"rule_value={rule_match_value}, name={feature_name}, key={cond_key}",
-                )
-                return False
             else:
-                context_value = context[cond_key]
+                context_key_present = cond_key in context
+                context_value = context.get(cond_key)
 
-            if not self._match_by_action(action=cond_action, condition_value=cond_value, context_value=context_value):
+            if not self._match_by_action(
+                action=cond_action,
+                condition_value=cond_value,
+                context_value=context_value,
+                context_key_present=context_key_present,
+            ):
                 self.logger.debug(
                     f"rule did not match action, rule_name={rule_name}, rule_value={rule_match_value}, "
                     f"name={feature_name}, context_value={str(context_value)} ",

--- a/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
+++ b/aws_lambda_powertools/utilities/feature_flags/feature_flags.py
@@ -115,7 +115,7 @@ class FeatureFlags:
             return False
 
         for condition in conditions:
-            context_value = context.get(condition.get(schema.CONDITION_KEY, ""))
+            cond_key = condition.get(schema.CONDITION_KEY, "")
             cond_action = condition.get(schema.CONDITION_ACTION, "")
             cond_value = condition.get(schema.CONDITION_VALUE)
 
@@ -125,7 +125,17 @@ class FeatureFlags:
                 schema.RuleAction.SCHEDULE_BETWEEN_DATETIME_RANGE.value,
                 schema.RuleAction.SCHEDULE_BETWEEN_DAYS_OF_WEEK.value,
             ):
-                context_value = condition.get(schema.CONDITION_KEY)  # e.g., CURRENT_TIME
+                context_value = cond_key  # e.g., CURRENT_TIME
+            elif cond_key not in context:
+                # A key absent from the context never satisfies a condition. Without this guard, `None`
+                # would be compared as a regular value and negative actions (NOT_EQUALS, NOT_IN, ...) would match.
+                self.logger.debug(
+                    f"rule did not match, context key not found, rule_name={rule_name}, "
+                    f"rule_value={rule_match_value}, name={feature_name}, key={cond_key}",
+                )
+                return False
+            else:
+                context_value = context[cond_key]
 
             if not self._match_by_action(action=cond_action, condition_value=cond_value, context_value=context_value):
                 self.logger.debug(

--- a/docs/utilities/feature_flags.md
+++ b/docs/utilities/feature_flags.md
@@ -444,6 +444,8 @@ The `action` configuration can have the following values, where the expressions 
 ???+ info
     The `key` and `value` will be compared to the input from the `context` parameter.
 
+    If a condition's `key` is not present in `context`, the condition never matches, regardless of the action. For example, a `NOT_EQUALS` rule on `tier` will not match a request that carries no `tier` at all.
+
 ???+ "Time based keys"
 
     For time based keys, we provide a list of predefined keys. These will automatically get converted to the corresponding timestamp on each invocation of your Lambda function.

--- a/tests/functional/feature_flags/_boto3/test_feature_flags.py
+++ b/tests/functional/feature_flags/_boto3/test_feature_flags.py
@@ -1767,3 +1767,67 @@ def test_exception_handler(mocker, config):
             context={"tenant_id": "not a list value"},
             default=False,
         )
+
+
+def test_flags_missing_context_key_still_invokes_validation_exception_handler(mocker, config):
+    # GIVEN an ANY_IN_VALUE rule and a handler registered for the ValueError the comparator raises
+    # when the context value is not a list
+    mocked_app_config_schema = {
+        "my_feature": {
+            "default": False,
+            "rules": {
+                "tenant_id is in allowed list": {
+                    "when_match": True,
+                    "conditions": [
+                        {
+                            "action": RuleAction.ANY_IN_VALUE.value,
+                            "key": "tenant_id",
+                            "value": ["Akua", "John", "Maria", "Pat"],
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    feature_flags = init_feature_flags(mocker, mocked_app_config_schema, config)
+    handled = []
+
+    @feature_flags.validation_exception_handler(ValueError)
+    def handle_invalid_context(exc):
+        handled.append(exc)
+        return True
+
+    # WHEN the context does not carry the key at all
+    toggle = feature_flags.evaluate(name="my_feature", context={}, default=False)
+
+    # THEN the handler is still called and its result is honoured, as it was before missing keys were guarded
+    assert len(handled) == 1
+    assert toggle is True
+
+
+def test_flags_missing_context_key_no_match_without_handler_for_raising_action(mocker, config):
+    # GIVEN an ANY_IN_VALUE rule and no exception handler registered
+    mocked_app_config_schema = {
+        "my_feature": {
+            "default": False,
+            "rules": {
+                "tenant_id is in allowed list": {
+                    "when_match": True,
+                    "conditions": [
+                        {
+                            "action": RuleAction.ANY_IN_VALUE.value,
+                            "key": "tenant_id",
+                            "value": ["Akua", "John", "Maria", "Pat"],
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    feature_flags = init_feature_flags(mocker, mocked_app_config_schema, config)
+
+    # WHEN the context does not carry the key at all
+    toggle = feature_flags.evaluate(name="my_feature", context={}, default=False)
+
+    # THEN the rule does not match
+    assert toggle is False

--- a/tests/functional/feature_flags/_boto3/test_feature_flags.py
+++ b/tests/functional/feature_flags/_boto3/test_feature_flags.py
@@ -883,6 +883,71 @@ def test_flags_not_equal_match(mocker, config):
     assert toggle == expected_value
 
 
+@pytest.mark.parametrize(
+    "action, value",
+    [
+        (RuleAction.NOT_EQUALS.value, "premium"),
+        (RuleAction.NOT_IN.value, ["premium", "enterprise"]),
+        (RuleAction.KEY_NOT_IN_VALUE.value, ["premium", "enterprise"]),
+        (RuleAction.VALUE_NOT_IN_KEY.value, "premium"),
+    ],
+)
+def test_flags_negative_action_no_match_when_context_key_missing(mocker, config, action, value):
+    # GIVEN a rule with a negative action on key "tier"
+    mocked_app_config_schema = {
+        "my_feature": {
+            "default": False,
+            "rules": {
+                "non premium users": {
+                    "when_match": True,
+                    "conditions": [
+                        {
+                            "action": action,
+                            "key": "tier",
+                            "value": value,
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    feature_flags = init_feature_flags(mocker, mocked_app_config_schema, config)
+
+    # WHEN evaluating with a context that doesn't carry "tier" at all
+    toggle = feature_flags.evaluate(name="my_feature", context={"username": "a"}, default=False)
+
+    # THEN the rule must not match; a missing key never satisfies a condition
+    assert toggle is False
+
+
+def test_flags_not_equal_match_when_context_key_is_none(mocker, config):
+    # GIVEN a NOT_EQUALS rule on key "tier"
+    mocked_app_config_schema = {
+        "my_feature": {
+            "default": False,
+            "rules": {
+                "non premium users": {
+                    "when_match": True,
+                    "conditions": [
+                        {
+                            "action": RuleAction.NOT_EQUALS.value,
+                            "key": "tier",
+                            "value": "premium",
+                        },
+                    ],
+                },
+            },
+        },
+    }
+    feature_flags = init_feature_flags(mocker, mocked_app_config_schema, config)
+
+    # WHEN the key is present but explicitly set to None
+    toggle = feature_flags.evaluate(name="my_feature", context={"tier": None}, default=False)
+
+    # THEN the value is still compared as usual (None != "premium"), so the rule matches
+    assert toggle is True
+
+
 # Test less than
 def test_flags_less_than_no_match_1(mocker, config):
     expected_value = False


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8424

## Summary

### Changes

A condition whose `key` is absent from the evaluation context no longer matches, regardless of action.

`_evaluate_conditions` read the context with `context.get(key)`, so an absent key was compared as `None`. Negative actions then matched trivially: `None != "premium"` is `True`, `None not in [...]` is `True`. Rules such as "tier is not premium" fired for anonymous or partially populated requests that carried no `tier` at all.

`_match_by_action` now takes a `context_key_present` flag. The comparator runs exactly as before; if the key was absent and the comparator returned normally, the result is forced to `False`. Running the comparator first matters: actions such as `ANY_IN_VALUE` raise `ValueError` for a `None` context value, and that exception must keep reaching any `validation_exception_handler` the user registered, with the handler's return value honoured. Only the "comparator quietly returned `True` for an absent key" path changes.

A key that is present with an explicit `None` value is still compared as before, so this is about absence rather than falsiness. Time-based actions are unaffected since they never read the user context.

#### Why this is a regression fix, not a behaviour change

From the utility's introduction (#563, 2021) until v2.11.0, `_match_by_action` opened with:

```python
if not context_value:
    return False
```

so a missing key (`None`) could never satisfy a condition, for any action. #2052 (fixing #2051) removed that guard so that falsy values such as `0`, `""`, and `False` could be compared. That was the intended scope of the change; allowing an absent key to satisfy `NOT_EQUALS` and friends was a side effect, never documented, and no test asserted it. This PR restores the original "missing key never matches" semantics while keeping the #2051 behaviour for keys that are present with a falsy value.

Tests cover: the four negative actions with a missing key; an explicit `None` value still being compared; a missing key with `ANY_IN_VALUE` and a registered `ValueError` handler, asserting the handler is called and its result used; and the same without a handler, asserting no match. The behaviour is also now documented in the rule actions section of the feature flags docs.

### User experience

Given:

```json
{
  "discount_banner": {
    "default": false,
    "rules": {
      "non premium users": {
        "when_match": true,
        "conditions": [{ "action": "NOT_EQUALS", "key": "tier", "value": "premium" }]
      }
    }
  }
}
```

| `context`             | Before v2.11.0 | v2.11.0 to now | After   |
| --------------------- | -------------- | -------------- | ------- |
| `{}`                  | `False`        | `True`         | `False` |
| `{"tier": None}`      | `False`        | `True`         | `True`  |
| `{"tier": ""}`        | `False`        | `True`         | `True`  |
| `{"tier": "free"}`    | `True`         | `True`         | `True`  |
| `{"tier": "premium"}` | `False`        | `False`        | `False` |

Only the first row changes. `validation_exception_handler` behaviour is unchanged: comparators raise for the same inputs as before and handlers see the same exceptions.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.