### PR TITLE
chore(feature_flags): warn on empty schema and empty rules

### DIFF
--- a/aws_lambda_powertools/utilities/feature_flags/schema.py
+++ b/aws_lambda_powertools/utilities/feature_flags/schema.py
@@ -212,6 +212,12 @@ class SchemaValidator(BaseValidator):
         if not isinstance(self.schema, dict):
             raise SchemaValidationError(f"Features must be a dictionary, schema={str(self.schema)}")
 
+        if not self.schema:
+            # Often the result of an envelope query that matched nothing (e.g. a typo'd feature name).
+            # Harmless for evaluation, so warn rather than raise.
+            self.logger.warning("Feature flags schema is empty, no features to validate")
+            return
+
         features = FeaturesValidator(schema=self.schema, logger=self.logger)
         features.validate()
 
@@ -232,7 +238,12 @@ class FeaturesValidator(BaseValidator):
         for name, feature in self.schema.items():
             self.logger.debug(f"Attempting to validate feature '{name}'")
             boolean_feature: bool = self.validate_feature(name, feature)
-            rules = RulesValidator(feature=feature, boolean_feature=boolean_feature, logger=self.logger)
+            rules = RulesValidator(
+                feature=feature,
+                boolean_feature=boolean_feature,
+                logger=self.logger,
+                feature_name=name,
+            )
             rules.validate()
 
     # returns True in case the feature is a regular feature flag with a  boolean default value
@@ -260,16 +271,29 @@ class RulesValidator(BaseValidator):
         feature: dict[str, Any],
         boolean_feature: bool,
         logger: logging.Logger | Logger | None = None,
+        feature_name: str | None = None,
     ):
         self.feature = feature
-        self.feature_name = next(iter(self.feature))
+        self.feature_name = feature_name if feature_name is not None else next(iter(self.feature))
         self.rules: dict | None = self.feature.get(RULES_KEY)
         self.logger = logger or LOGGER
         self.boolean_feature = boolean_feature
 
     def validate(self):
         if not self.rules:
-            self.logger.debug("Rules are empty, ignoring validation")
+            if RULES_KEY in self.feature:
+                # 'rules' was authored but is empty (e.g. {}, [], None). Evaluation falls back to 'default',
+                # so this is harmless, but it likely signals a mistake. A non-dict type is called out separately
+                # because a non-empty value of that type would be rejected below.
+                if isinstance(self.rules, dict) or self.rules is None:
+                    self.logger.warning(f"Feature has 'rules' but it is empty, feature={self.feature_name}")
+                else:
+                    self.logger.warning(
+                        f"Feature 'rules' should be a dictionary but is an empty {type(self.rules).__name__}, "
+                        f"feature={self.feature_name}",
+                    )
+            else:
+                self.logger.debug("Rules are empty, ignoring validation")
             return
 
         if not isinstance(self.rules, dict):

--- a/tests/functional/feature_flags/_boto3/test_schema_validation.py
+++ b/tests/functional/feature_flags/_boto3/test_schema_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 
 import pytest
@@ -39,6 +40,44 @@ def test_empty_features_not_fail():
     validator.validate()
 
 
+def test_empty_features_emits_warning(caplog):
+    # GIVEN an empty top-level document, e.g. the result of an envelope query that matched nothing
+    validator = SchemaValidator(schema={})
+
+    # WHEN validating
+    with caplog.at_level(logging.WARNING):
+        validator.validate()
+
+    # THEN a warning is emitted and nothing is raised
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert "schema is empty" in caplog.records[0].getMessage()
+
+
+def test_features_not_empty_no_warning(caplog):
+    # GIVEN a well-formed document with rules
+    schema = {
+        "my_feature": {
+            FEATURE_DEFAULT_VAL_KEY: False,
+            RULES_KEY: {
+                "tenant match": {
+                    RULE_MATCH_VALUE: True,
+                    CONDITIONS_KEY: [
+                        {CONDITION_ACTION: RuleAction.EQUALS.value, CONDITION_KEY: "tenant_id", CONDITION_VALUE: "6"},
+                    ],
+                },
+            },
+        },
+    }
+
+    # WHEN validating
+    with caplog.at_level(logging.WARNING):
+        SchemaValidator(schema).validate()
+
+    # THEN no warning is emitted
+    assert not caplog.records
+
+
 @pytest.mark.parametrize(
     "schema",
     [
@@ -65,6 +104,49 @@ def test_valid_feature_dict():
     schema = {"my_feature": {FEATURE_DEFAULT_VAL_KEY: False}}
     validator = SchemaValidator(schema)
     validator.validate()
+
+
+@pytest.mark.parametrize(
+    "rules, expected_message",
+    [
+        pytest.param({}, "Feature has 'rules' but it is empty, feature=my_feature", id="empty_dict"),
+        pytest.param(None, "Feature has 'rules' but it is empty, feature=my_feature", id="none"),
+        pytest.param(
+            [],
+            "Feature 'rules' should be a dictionary but is an empty list, feature=my_feature",
+            id="empty_list",
+        ),
+        pytest.param(
+            "",
+            "Feature 'rules' should be a dictionary but is an empty str, feature=my_feature",
+            id="empty_str",
+        ),
+    ],
+)
+def test_feature_with_empty_rules_emits_warning(caplog, rules, expected_message):
+    # GIVEN a feature whose 'rules' key is present but falsy
+    schema = {"my_feature": {FEATURE_DEFAULT_VAL_KEY: False, RULES_KEY: rules}}
+
+    # WHEN validating
+    with caplog.at_level(logging.WARNING):
+        SchemaValidator(schema).validate()
+
+    # THEN a warning naming the feature is emitted and nothing is raised
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].getMessage() == expected_message
+
+
+def test_feature_without_rules_key_no_warning(caplog):
+    # GIVEN a feature that simply omits 'rules'
+    schema = {"my_feature": {FEATURE_DEFAULT_VAL_KEY: False}}
+
+    # WHEN validating
+    with caplog.at_level(logging.WARNING):
+        SchemaValidator(schema).validate()
+
+    # THEN no warning is emitted; omitting rules is the documented way to declare a static flag
+    assert not caplog.records
 
 
 def test_invalid_feature_default_value_is_not_boolean():


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8427

## Summary

### Changes

`SchemaValidator` now emits a `warning` log for documents that are valid but almost certainly not what the author meant. Nothing is raised, so every document that validated before still validates.

Three cases are covered:

- Empty top-level document (`{}`). Typically the result of an envelope query that matched nothing, e.g. a typo'd feature group name.
- A feature whose `rules` key is present but empty (`{}` or `None`).
- A feature whose `rules` key is present, empty, and not a dictionary (`[]`, `""`). This gets a more specific message because the same value, once populated, would be rejected with `SchemaValidationError`; the empty form only slipped through because `if not self.rules` short-circuits first.

Omitting `rules` entirely stays silent, since that is the documented way to declare a static flag.

While wiring the warning I found that `RulesValidator` derived `feature_name` from `next(iter(self.feature))`, i.e. the feature's first key (`"default"` in practice), not its name. `FeaturesValidator` now passes the real name in through a new optional `feature_name` argument, so the new warnings and the existing `Feature rules must be a dictionary, feature=...` error name the right feature. The old fallback is kept so direct construction without the argument keeps working.

Tests pin each warning's level and message, and pin the two silent paths (well-formed document, `rules` omitted) so the warnings do not become noisy.

The TypeScript port (aws-powertools/powertools-lambda-typescript#5614) warns on the same cases and throws only where Python throws, so documents stay portable between runtimes.

### User experience

No behaviour change for `evaluate` or `get_enabled_features`. The only difference is in logs:

| Document                                        | Before | After                                                                                |
| ----------------------------------------------- | ------ | ------------------------------------------------------------------------------------ |
| `{}`                                            | silent | `WARNING Feature flags schema is empty, no features to validate`                     |
| `{"f": {"default": false, "rules": {}}}`        | silent | `WARNING Feature has 'rules' but it is empty, feature=f`                             |
| `{"f": {"default": false, "rules": []}}`        | silent | `WARNING Feature 'rules' should be a dictionary but is an empty list, feature=f`     |
| `{"f": {"default": false}}`                     | silent | silent                                                                               |
| `{"f": {"default": false, "rules": "4"}}`       | raises | raises, now with `feature=f` instead of `feature=default`                            |

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.