### PR TITLE
chore(ci): retire Python 3.9 layer automation

### DIFF
--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -80,13 +80,11 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39-arm64
           - AWSLambdaPowertoolsPythonV3-python310-arm64
           - AWSLambdaPowertoolsPythonV3-python311-arm64
           - AWSLambdaPowertoolsPythonV3-python312-arm64
           - AWSLambdaPowertoolsPythonV3-python313-arm64
           - AWSLambdaPowertoolsPythonV3-python314-arm64
-          - AWSLambdaPowertoolsPythonV3-python39-x86_64
           - AWSLambdaPowertoolsPythonV3-python310-x86_64
           - AWSLambdaPowertoolsPythonV3-python311-x86_64
           - AWSLambdaPowertoolsPythonV3-python312-x86_64

--- a/.github/workflows/layer_govcloud.yml
+++ b/.github/workflows/layer_govcloud.yml
@@ -52,7 +52,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312
@@ -98,7 +97,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312
@@ -167,7 +165,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312

--- a/.github/workflows/layer_govcloud_verify.yml
+++ b/.github/workflows/layer_govcloud_verify.yml
@@ -28,7 +28,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312
@@ -59,7 +58,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312
@@ -91,7 +89,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312

--- a/.github/workflows/layers_partition_verify.yml
+++ b/.github/workflows/layers_partition_verify.yml
@@ -77,6 +77,7 @@ jobs:
     strategy:
       matrix:
         layer:
+          # Python 3.9 remains here to verify its final layer version.
           - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
@@ -94,9 +95,11 @@ jobs:
           aws-region: us-east-1
           mask-aws-account-id: true
       - name: Output ${{ matrix.layer }}-${{ matrix.arch }}
+        env:
+          VERSION: ${{ matrix.layer == 'AWSLambdaPowertoolsPythonV3-python39' && '27' || inputs.version }}
         # fetch the specific layer version information from the us-east-1 commercial region
         run: |
-          aws --region us-east-1 lambda get-layer-version-by-arn --arn 'arn:aws:lambda:us-east-1:017000801446:layer:${{ matrix.layer }}-${{ matrix.arch }}:${{ inputs.version }}' > '${{ matrix.layer }}-${{ matrix.arch }}.json'
+          aws --region us-east-1 lambda get-layer-version-by-arn --arn "arn:aws:lambda:us-east-1:017000801446:layer:${{ matrix.layer }}-${{ matrix.arch }}:${VERSION}" > '${{ matrix.layer }}-${{ matrix.arch }}.json'
       - name: Store Metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -120,6 +123,7 @@ jobs:
       matrix:
         region: ${{ fromJson(needs.setup.outputs.regions) }}
         layer:
+          # Python 3.9 remains here to verify its final layer version.
           - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
@@ -146,8 +150,10 @@ jobs:
           audience: ${{ needs.setup.outputs.aud }}
       - id: partition_version
         name: Partition Layer Version
+        env:
+          VERSION: ${{ matrix.layer == 'AWSLambdaPowertoolsPythonV3-python39' && '27' || inputs.partition_version || inputs.version }}
         run: |
-          echo 'partition_version=$([[ -n "${{ inputs.partition_version}}" ]] && echo ${{ inputs.partition_version}} || echo ${{ inputs.version }} )' >> "$GITHUB_OUTPUT"
+          echo "partition_version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Verify Layer
         run: |
           export layer_output='${{ matrix.layer }}-${{ matrix.arch }}-${{matrix.region}}.json'

--- a/.github/workflows/layers_partitions.yml
+++ b/.github/workflows/layers_partitions.yml
@@ -78,7 +78,6 @@ jobs:
     strategy:
       matrix:
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312
@@ -150,7 +149,6 @@ jobs:
       matrix:
         region: ${{ fromJson(needs.setup.outputs.regions) }}
         layer:
-          - AWSLambdaPowertoolsPythonV3-python39
           - AWSLambdaPowertoolsPythonV3-python310
           - AWSLambdaPowertoolsPythonV3-python311
           - AWSLambdaPowertoolsPythonV3-python312


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** closes #8434

## Summary

### Changes

- Remove Python 3.9 from partition and GovCloud deployment matrices.
- Remove Python 3.9 from GovCloud verification and region bootstrap matrices.
- Retain Python 3.9 in partition verification, pinned to its final layer version, 27.
- Continue verifying Python 3.10-3.14 against the requested layer version.

### User experience

New partition layer releases no longer fail while looking for nonexistent Python 3.9 artifacts after version 27. Existing Python 3.9 layers remain available and their final commercial and partition artifacts continue to receive SHA verification.

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-python/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/python/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-python/blob/develop/.github/semantic.yml
- If relevant, add tests that prove that the change is effective and works
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.